### PR TITLE
Changed filter_lanes() in run-pipeline then killed Sanity Clause in TrackQC_Fasta.pm.

### DIFF
--- a/modules/VertRes/Pipelines/TrackQC_Fastq.pm
+++ b/modules/VertRes/Pipelines/TrackQC_Fastq.pm
@@ -623,8 +623,7 @@ sub stats_and_graphs_provides
 {
     my ($self) = @_;
     my $sample_dir = $$self{'sample_dir'};
-    my @provides = ("$sample_dir/chrom-distrib.png","$sample_dir/gc-content.png",
-                        "$sample_dir/gc-depth.png","$sample_dir/fastqcheck.png");
+    my @provides = ("$sample_dir/_graphs.done");
     return \@provides;
 }
 
@@ -742,11 +741,6 @@ sub run_graphs
                 });
     }
 
-    my $stats = do $dump_file;
-    if ( $total_reads != $$stats{reads_total} )
-    {
-        $self->throw("Sanity check failed, different number of reads in fastq files and $bam_file ($total_reads .. $$stats{reads_total})\n");
-    }
 }
 
 

--- a/scripts/run-pipeline
+++ b/scripts/run-pipeline
@@ -617,6 +617,7 @@ sub filter_lanes {
             foreach my $regex (@{$array}) {
                 $regex =~ s/^\^//;
                 $regex =~ s/\$$//;
+		$regex = quotemeta $regex;
                 push(@regexs, qr/^$regex$/);
             }
             


### PR DESCRIPTION
I added quotemeta to the regular expression in filter_lanes() in run-pipeline. This was to cope with projects that had brackets in the title and to deal with any future project titles or sample names containing punctuation, slashes, etc. 

This shouldn't affect any existing users _unless_ they've been using regular expressions for the limits in their conf files ( eg 'sample_\d+' ). If this is the case then let me know and I'll try applying quotemeta solely to projects.

I also made a couple of minor bug-fixes to TrackQC_Fasta.pm. I changed stats_and_graphs_provides() to use _graphs.done file. I removed the sanity check from run_graphs() as the status.dump file used for check is no longer generated.
