### PR TITLE
Skip genotype

### DIFF
--- a/modules/VertRes/Pipelines/TrackQC_Bam.pm
+++ b/modules/VertRes/Pipelines/TrackQC_Bam.pm
@@ -423,6 +423,10 @@ sub check_genotype
 {
     my ($self,$lane_path,$lock_file) = @_;
 
+    # Skip Genotype Check
+    if(exists $$self{'skip_genotype'} && $$self{'skip_genotype'})
+    { $self->debug("Skipping genotype check.\n"); return $$self{'Yes'}; }
+
     if ( !$$self{snps} ) { $self->throw("Missing the option snps.\n"); }
 
     my $name = $$self{lane};
@@ -653,7 +657,7 @@ sub auto_qc
     my ($test,$status,$reason);
 
     # Genotype check results
-    if ( exists($$self{auto_qc}{gtype_regex}) )
+    if ( exists($$self{auto_qc}{gtype_regex}) && !(exists $$self{'skip_genotype'} && $$self{'skip_genotype'}) )
     {
         my $gtype  = VertRes::Utils::GTypeCheck::get_status("$sample_dir/${name}.gtype");
         $test   = 'Genotype check';
@@ -878,7 +882,22 @@ sub update_db
     my $rmdup_bases_total    = $bc->get('total_length');
     my $rmdup_bases_trimmed  = $bc->get('bases_trimmed');
 
-    my $gtype = VertRes::Utils::GTypeCheck::get_status("$sample_dir/${name}.gtype");
+    my $gtype;
+    unless(exists $$self{'skip_genotype'} && $$self{'skip_genotype'})
+    {
+	# Get genotype results
+	$gtype = VertRes::Utils::GTypeCheck::get_status("$sample_dir/${name}.gtype");
+    }
+    else
+    {
+	# Skip genotype results
+	$gtype = {
+	    status   => 'unchecked',
+	    expected => undef,
+	    found    => undef,
+	    ratio    => undef,
+	};
+    }
 
     my %images = ();
     if ( -e "$sample_dir/chrom-distrib.png" ) { $images{'chrom-distrib.png'} = 'Chromosome Coverage'; }


### PR DESCRIPTION
I don't think Pathogens is using the genotype test at all with our pipelines (at the moment) and we would like the option of omitting the test. I've added the option (well, the option to skip the test) to the TrackQC_Bam.pm module. Please let me know if this meets with your approval or if you need anything more from me, etc.

Added option to skip genotype test during QC by adding/uncommenting the following line in the 'data' section of conf file:
skip_genotype => 1, 

Changes made in the TrackQC_Bam.pm module in: 
 check_genotype() 
  If $$self{'skip_genotype'} exists and is true then send debug message and return 'Yes'.
 auto_qc()
  Genotype check section skipped if $$self{'skip_genotype'} exists and is true. Results in omission of section in auto_qc.txt output file.
 update_db()
  Unless $$self{'skip_genotype'} exists and is true then get the gtype results. Otherwise set $$gtype{status} as 'unchecked' and other gtype data as undef.
