### PR TITLE
Sanity check

### DIFF
--- a/modules/VertRes/Pipelines/TrackQC_Fastq.pm
+++ b/modules/VertRes/Pipelines/TrackQC_Fastq.pm
@@ -54,6 +54,14 @@ our @actions =
         'provides' => \&map_sample_provides,
     },
 
+    # Check sanity, namely the reference sequence. Inherited from TrackQC_Bam.
+    {
+        'name'     => 'check_sanity',
+        'action'   => \&VertRes::Pipelines::TrackQC_Bam::check_sanity,
+        'requires' => \&VertRes::Pipelines::TrackQC_Bam::check_sanity_requires, 
+        'provides' => \&VertRes::Pipelines::TrackQC_Bam::check_sanity_provides,
+    },
+
     # Runs glf to check the genotype. Inherited from TrackQC_Bam.
     {
         'name'     => 'check_genotype',


### PR DESCRIPTION
Added a sanity check on bam file to TrackQC_Fastq.pm pipeline by calling sanity_check() from TrackQC_Bam.pm. 

sanity_check() was added by Jim on Jan 11th and appears to be a replacement for the sanity check (that used _stats.dump) which was removed by me on Feb 25th. The _stats.dump file was removed in Jim's Jan 11th update.
