### PR TITLE
Update lane stats

### DIFF
--- a/modules/VertRes/Pipelines/Import.pm
+++ b/modules/VertRes/Pipelines/Import.pm
@@ -492,6 +492,20 @@ sub update_db
         $vrfile->update();
     }
 
+    # Update the lane stats
+    my $read_len=0;
+    my $raw_reads=0;
+    my $raw_bases=0;
+    my $vfiles=$vrlane->files;
+    for my $vfile(@$vfiles){
+	$raw_reads+=$vfile->raw_reads;
+	$raw_bases+=$vfile->raw_bases;
+	$read_len=$vfile->read_len;
+    }
+    $vrlane->raw_reads($raw_reads);
+    $vrlane->raw_bases($raw_bases);
+    $vrlane->read_len($read_len);
+
     # Finally, change the import status of the lane, so that it will not be picked up again
     #   by the run-pipeline script.
     $vrlane->is_processed('import',1);


### PR DESCRIPTION
The number of raw bases wasn't being updated for multiplexed lanes. It looks like this section of Raeece's code was lost during a commit. 

I mentioned this to Jim a couple of weeks ago. Sorry for the delay submitting this - a problem with importing non-human fastq files may also have been introduced in the commit where Raeece's code was lost but I've not been able to look in to that.
