### PR TITLE
Skip auto qc

### DIFF
--- a/modules/VertRes/Pipelines/TrackQC_Bam.pm
+++ b/modules/VertRes/Pipelines/TrackQC_Bam.pm
@@ -652,6 +652,10 @@ sub auto_qc
 {
     my ($self,$lane_path,$lock_file) = @_;
 
+    # Skip Auto QC
+    if(exists $$self{'skip_auto_qc'} && $$self{'skip_auto_qc'})
+    { $self->debug("Skipping auto_qc.\n"); return $$self{'Yes'}; }
+
     my $sample_dir = "$lane_path/$$self{sample_dir}";
     if ( !$$self{db} ) { $self->throw("Expected the db key.\n"); }
 


### PR DESCRIPTION
This was a request that I add an option for skipping the Auto QC stage of the QC pipeline in a similar manner to the skip genotype option added in February. 

I added the option to skip the Auto QC stage during QC by adding/uncommenting the following line in the 'data' section of conf file:
skip_auto_qc => 1,

There's one change at the beginning of auto_qc():
If $$self{'skip_auto_qc'} exists and is true then send debug message and return 'Yes'.
