### PR TITLE
Study title

### DIFF
--- a/modules/Sfind/Study.pm
+++ b/modules/Sfind/Study.pm
@@ -241,7 +241,7 @@ has 'description'  => (
 
 has 'abstract'  => (
     is          => 'ro',
-    isa         => 'Str',
+    isa         => 'Maybe[Str]',
 );
 
 has 'sponsor'  => (
@@ -304,7 +304,7 @@ has 'visibility'=> (
 
 has 'title'=> (
     is          => 'ro',
-    isa         => 'Str',
+    isa         => 'Maybe[Str]',
     init_arg    => 'study_title',
 );
 


### PR DESCRIPTION
 Set title and abstract to Maybe[Str] instead of Str.

Modification to cope with old studies. Some of our studies have the title or abstract set to null in the warehouse_two database but Moose requires strings for these fields and consequently they can't pass Moose's type constraints.
