### PR TITLE
Changes to TrackQC_Fastq pipeline.

### DIFF
--- a/modules/VertRes/Pipelines/TrackQC_Bam.pm
+++ b/modules/VertRes/Pipelines/TrackQC_Bam.pm
@@ -949,6 +949,10 @@ sub update_db
     if ( -e "$sample_dir/${name}_1.nadapters" ) { $nadapters += do "$sample_dir/${name}_1.nadapters"; }
     if ( -e "$sample_dir/${name}_2.nadapters" ) { $nadapters += do "$sample_dir/${name}_2.nadapters"; }
 
+    # Length of reference sequence mapped (for TrackQC_Fasta pipeline.)
+    my $sequence_mapped = undef;
+    if ( -e "$sample_dir/${name}.cover" ) { $sequence_mapped = do "$sample_dir/${name}.cover"; }
+
     $vrtrack->transaction_start();
 
     # Now call the database API and fill the mapstats object with values
@@ -997,6 +1001,10 @@ sub update_db
         $img->caption($caption);
         $img->update;
     }
+
+    # Length of reference sequence mapped
+    if(defined $sequence_mapped)
+    { $mapping->target_bases_mapped($sequence_mapped); }
 
     $mapping->update;
 


### PR DESCRIPTION
There are two changes to the Fastq QC pipeline in this pull request. 
1. I removed the redundant graphs generated in the TrackQC_Fastq pipeline stats_and_graphs section. 
2. We wanted to add a check giving the percentage of the reference genome mapped for our version of QC Grind. 
   
   There is a change in the TrackQC_Fastq stats_and_graphs section. I calculated the coverage using samtools pileup and output the result to a file(lanename.cover) in the sample directory. 
   
   I altered TrackQC_Bam to get the value in lanename.cover (only if the file exists) and to store it in the target_bases_mapped column of the mapstats table. The change will not affect the TrackQC_Bam pipeline.

Our version of QC Grind calculates the percentage of the reference genome covered using the length of the reference sequence from the assembly table.
