### PR TITLE
Allow for lanes to be filtered in the pipelines by species

### DIFF
--- a/modules/VertRes/Utils/Hierarchy.pm
+++ b/modules/VertRes/Utils/Hierarchy.pm
@@ -130,6 +130,7 @@ sub parse_lane {
                                       and library_raw)
            lane           => string, (aka read group)
            centre         => string, (the sequencing centre name)
+           species        => string,
            insert_size    => int, (can be undef if this lane is single-ended)
            withdrawn      => boolean,
            imported       => boolean,
@@ -226,6 +227,7 @@ sub lane_info {
     }
     $info{sample} = $objs{sample}->name || $self->throw("sample name wasn't known for $rg");
     $info{individual} = $objs{individual}->name || $self->throw("individual name wasn't known for $rg");
+    $info{species} =  $objs{species}->name || $self->throw("species name wasn't known for $rg");
     $info{individual_acc} = $objs{individual}->acc; # || $self->throw("sample accession wasn't known for $rg");
     unless ($args{no_coverage}) {
         $info{individual_coverage} = $self->hierarchy_coverage(individual => [$info{individual}],
@@ -259,6 +261,7 @@ sub lane_info {
            platform => VRTrack::Seq_tech object
            centre => VRTrack::Seq_centre object
            library => VRTrack::Library object
+           species => VRTrack::Species object
  Args    : VRTrack::Lane object
 
 =cut
@@ -272,6 +275,7 @@ sub lane_hierarchy_objects {
     my $st = $lib->seq_tech;
     my $sample = VRTrack::Sample->new($vrtrack, $lib->sample_id);
     my $individual = $sample->individual;
+    my $species = $individual->species;
     my $pop = $individual->population;
     my $project_obj = VRTrack::Project->new($vrtrack, $sample->project_id);
     my $study_obj = VRTrack::Study->new($vrtrack, $project_obj->study_id) if $project_obj->study_id;
@@ -283,7 +287,8 @@ sub lane_hierarchy_objects {
             population => $pop,
             platform => $st,
             centre => $sc,
-            library => $lib);
+            library => $lib,
+            species => $species);
 }
 
 =head2 hierarchy_coverage

--- a/scripts/run-pipeline
+++ b/scripts/run-pipeline
@@ -678,7 +678,7 @@ sub filter_lanes {
     my ($limits, $hnames, $vrtrack, $config) = @_;
     
     my %valid_limits;
-    foreach my $limit_type (qw(project sample individual population technology seq_tech centre library lane)) {
+    foreach my $limit_type (qw(project sample individual population technology seq_tech centre library lane species)) {
         if (defined $limits->{$limit_type}) {
             my $array = $limits->{$limit_type};
             unless (ref($array) && ref($array) eq 'ARRAY') {


### PR DESCRIPTION
Add species to the list of filters/limits when getting lanes to run the pipelines.
Of most use to QC and mapping where you have multiple species in one study & want to map them to different references.
