### PR TITLE
Check bams have reads before downloading from irods

### DIFF
--- a/modules/VertRes/Pipelines/Import_iRODS.pm
+++ b/modules/VertRes/Pipelines/Import_iRODS.pm
@@ -129,6 +129,13 @@ sub get_files
         my $outfile = $1;
         if ( -e $outfile ) { next; }
 
+        # Check if the BAM contains any reads.
+        if( $irods->get_total_reads($ifile) == 0)
+        {
+          $self->log("No reads in BAM file");
+          next;
+        }
+
         # Get the BAM index
         my $bai = $ifile;
         $bai =~ s/\.bam$/.bai/i;

--- a/modules/VertRes/Utils/Hierarchy.pm
+++ b/modules/VertRes/Utils/Hierarchy.pm
@@ -55,7 +55,7 @@ our $DEFAULT_DB_SETTINGS = {host => $ENV{VRTRACK_HOST},
                             user => $ENV{VRTRACK_RO_USER},
                             database => 'g1k_meta'};
 
-our $nfs_disc_basename = '/nfs/vertres';
+our $nfs_disc_basename = VertRes::Utils::VRTrackFactory->nfs_disc_basename();
 
 
 =head2 new

--- a/modules/VertRes/Utils/VRTrackFactory.pm
+++ b/modules/VertRes/Utils/VRTrackFactory.pm
@@ -44,6 +44,7 @@ my $READ_USER = $ENV{VRTRACK_RO_USER};
 my $WRITE_USER = $ENV{VRTRACK_RW_USER};
 my $WRITE_PASS = $ENV{VRTRACK_PASSWORD};
 my $FSU_FILE_EXISTS_DB_NAME = $ENV{FSU_FILE_EXISTS_DB_NAME} || 'vrtrack_fsu_file_exists';
+my $NFS_DISC_BASENAME = $ENV{NFS_DISC_BASENAME} || '/nfs/vertres';
 
 
 =head2 new
@@ -182,6 +183,21 @@ sub databases {
 sub fsu_file_exists_db_name
 {
   return $FSU_FILE_EXISTS_DB_NAME;
+}
+
+
+=head2 nfs_disc_basename
+
+ Title   : nfs_disc_basename
+ Usage   : my $nfs_disk_basename = VertRes::Utils::VRTrackFactory->nfs_disc_basename();
+ Function: Base directory name for archived data
+ Returns : directory name
+
+=cut
+
+sub nfs_disc_basename
+{
+  return $NFS_DISC_BASENAME;
 }
 
 

--- a/modules/VertRes/Wrapper/iRODS.pm
+++ b/modules/VertRes/Wrapper/iRODS.pm
@@ -227,3 +227,22 @@ sub get_file {
     return system(@args);
 }
 
+
+=head2 get_total_reads
+
+    Description : returns the total nubmer of reads in the bam file
+    Arg [1]     : irods file location
+    Example     : my $total_reads = $irods->get_total_reads('/seq/1234/1234_5.bam');
+    Returntype  : integer number of reads
+
+=cut
+
+sub get_total_reads {
+  my ($self, $file) = @_;
+  my $cmd = join "/",($self->{icommands},"imeta ls -d $file total_reads | grep value | awk '{ print $2 }'");
+
+  my $total_reads = `$cmd`;
+  chomp $total_reads;
+  return $total_reads;
+}
+

--- a/modules/VertRes/Wrapper/iRODS.pm
+++ b/modules/VertRes/Wrapper/iRODS.pm
@@ -239,10 +239,11 @@ sub get_file {
 
 sub get_total_reads {
   my ($self, $file) = @_;
-  my $cmd = join "/",($self->{icommands},"imeta ls -d $file total_reads | grep value | awk '{ print $2 }'");
+  my $cmd = join "/",($self->{icommands},"imeta ls -d $file total_reads | grep value");
 
-  my $total_reads = `$cmd`;
-  chomp $total_reads;
-  return $total_reads;
+  my $total_reads_value = `$cmd`;
+  my @total_reads = split(/ /,$total_reads_value);
+  chomp $total_reads[1];
+  return $total_reads[1];
 }
 


### PR DESCRIPTION
Check iRODs before downloading bam files. If there are no reads, log it and move on.
Also remove a hardcoded variable (defaults to hardcoded vertreseq value).
