### PR TITLE
Mapping Command Lines

### DIFF
--- a/modules/VertRes/Pipelines/Mapping.pm
+++ b/modules/VertRes/Pipelines/Mapping.pm
@@ -830,7 +830,8 @@ close(\$samfh);
                                   ref_dict => '$ref_fa.dict',
                                   ref_name => '$self->{assembly_name}',
                                   program => \$mapper->name,
-                                  program_version => \$mapper->version);
+                                  program_version => \$mapper->version,
+                                  command_line => [\$mapper->command_line]);
 \$sam_util->throw("Failed to add sam header!") unless \$ok;
 
 # convert to mate-fixed sorted bam

--- a/modules/VertRes/Utils/Mappers/bwa.pm
+++ b/modules/VertRes/Utils/Mappers/bwa.pm
@@ -50,7 +50,6 @@ sub new {
     my ($class, @args) = @_;
     
     my $self = $class->SUPER::new(@args);
-    
     return $self;
 }
 
@@ -208,6 +207,7 @@ sub do_mapping {
     
     my $wrapper = $self->wrapper;
     $wrapper->do_mapping(@args, aln_q => $aln_q);
+    $self->_add_command_line($wrapper->command_line());
     
     # bwa directly generates sam files, so nothing futher to do
     

--- a/modules/VertRes/Utils/Mappers/smalt.pm
+++ b/modules/VertRes/Utils/Mappers/smalt.pm
@@ -162,10 +162,11 @@ sub do_mapping {
     }
     
     my @args = $self->_do_mapping_args(\%do_mapping_args, %input_args);
-    
+
     my $wrapper = $self->wrapper;
     $wrapper->do_mapping(@args);
-    
+    $self->_add_command_line($wrapper->command_line());
+
     # smalt directly generates sam files, so nothing futher to do
     
     return $wrapper->run_status >= 1;

--- a/modules/VertRes/Utils/Mapping.pm
+++ b/modules/VertRes/Utils/Mapping.pm
@@ -72,7 +72,8 @@ sub new {
     my ($class, @args) = @_;
     
     my $self = $class->SUPER::new(@args);
-    
+    $self->{_command_line} = []; # List of commands run.
+
     return $self;
 }
 
@@ -562,6 +563,45 @@ sub get_mapping_stats {
     $stats{percent_properly_paired} = $stats{total_reads} ? sprintf("%0.2f", ((100 / $stats{total_reads}) * $stats{mapped_reads_in_proper_pairs})) : 0;
     
     return %stats;
+}
+
+=head2 command_line
+
+ Title   : command_line
+ Usage   : $mapper->command_line();
+           $self->command_line(@my_command_lines);
+ Function: Get/set list of commands executed by wrapper
+ Example : $self->command_line($wrapper->command_line());
+ Returns : list of command line strings executed by the wrapper
+ Args    : list of strings
+
+=cut
+
+sub command_line
+{
+    my $self = shift;
+    $self->{_command_line} = \@_ if @_; 
+    return @{$self->{_command_line}};
+}
+
+=head2 _add_command_line
+
+ Title   : _add_command_line
+ Usage   : $self->_add_command_line($my_command_line);
+           $self->_add_command_line(@my_command_lines);
+ Function: Internal method to add command line strings to record of command lines 
+           executed by wrapper.
+ Example : $self->_add_command_line($wrapper->command_line());
+ Returns : n/a
+ Args    : list of strings
+
+=cut
+
+sub _add_command_line
+{
+    my $self = shift;
+    push((@{$self->{_command_line}}),@_) if @_;
+    return @{$self->{_command_line}};
 }
 
 1;

--- a/modules/VertRes/Wrapper/MapperI.pm
+++ b/modules/VertRes/Wrapper/MapperI.pm
@@ -336,6 +336,7 @@ sub simple_run {
     $cmd = $exe.' '.$cmd;
     $self->debug("[$time{'yyyy/mm/dd hh:mm:ss'}] will run command '$cmd'");
     system($cmd) && $self->throw("command '$cmd' failed");
+    $self->_add_command_line($cmd);
 }
 
 1;

--- a/modules/VertRes/Wrapper/WrapperI.pm
+++ b/modules/VertRes/Wrapper/WrapperI.pm
@@ -83,7 +83,9 @@ sub new {
     $self->_set_params_and_switches_from_args(@args);
     
     $self->_set_run_status(-2);
-    
+
+    $self->{_command_line} = []; # Record of command lines executed by wrapper.
+
     return $self;
 }
 
@@ -203,7 +205,10 @@ sub _run {
     $run_method = '_'.$run_method.'_run';
     $self->_set_run_status(0);
     my @result = $self->$run_method($exe, $params, @extra_args);
-    
+
+    # Record commands run.
+    $self->_add_command_line("$exe $params @extra_args");
+
     return @result;
 }
 
@@ -717,5 +722,41 @@ sub DESTROY {
         waitpid $pid, 0;
     }
 }
+
+=head2 command_line
+
+ Title   : command_line
+ Usage   : $wrapper->command_line();
+ Function: Get/set command line strings
+ Returns : list of command line strings executed by the wrapper
+ Args    : list of strings
+
+=cut
+
+sub command_line
+{
+    my $self = shift;
+    $self->{_command_line} = \@_ if scalar @_; 
+    return @{$self->{_command_line}};
+}
+
+=head2 _add_command_line
+
+ Title   : _add_command_line
+ Usage   : $self->_add_command_line($my_command_line);
+           $self->_add_command_line(@my_command_lines);
+ Function: Internal method to add command line string to record of command lines 
+           executed by wrapper
+ Returns : n/a
+ Args    : list of strings
+
+=cut
+
+sub _add_command_line
+{
+    my $self = shift;
+    push((@{$self->{_command_line}}),@_) if scalar @_;
+}
+
 
 1;


### PR DESCRIPTION
Added record of command lines executed to bam header for mapping pipeline.

The ID tag for the top PG line is unchanged. Subsequent PG lines have an number for the ID tag. 
For example these are the PG lines generated for mapping with bwa:

@PG     ID:bwa  VN:0.5.9-r16    CL:bwa aln  -q 15 Influenzavirus_A_California_H1N1_Apr2009.fa 5515_2#1_1.1.fastq.gz  > 5515_2#1_1.1.sai  2> 5515_2#1_1.1.sai.err
@PG     ID:1    VN:0.5.9-r16    PP:bwa  CL:bwa aln  -q 15 Influenzavirus_A_California_H1N1_Apr2009.fa 5515_2#1_2.1.fastq.gz  > 5515_2#1_2.1.sai  2> 5515_2#1_2.1.sai.err
@PG     ID:2    VN:0.5.9-r16    PP:1    CL:bwa sampe  -a 2000 Influenzavirus_A_California_H1N1_Apr2009.fa 5515_2#1_1.1.sai 5515_2#1_2.1.sai 5515_2#1_1.1.fastq.gz 5515_2#1_2.1.fastq.gz  > 1.raw.sam_tmp

There is a change in the script generated at the map stage of the pipeline to set the add_sam_header function to pick-up the command lines 

There are changes in the wrappers to record the command lines: 
modules/VertRes/Wrapper/WrapperI.pm
modules/VertRes/Wrapper/MapperI.pm
modules/VertRes/Wrapper/bwa.pm

Changes in the mapper objects to pick-up the command lines:
modules/VertRes/Utils/Mapping.pm
modules/VertRes/Utils/Mappers/bwa.pm
modules/VertRes/Utils/Mappers/smalt.pm

And finally there's a change to the sam wrapper to add the command lines to the sam/bam header.

The changes work for mapping with either bwa or smalt.

Please let me know if there's anything you want me to add. 
