### PR TITLE
Set samtools wrapper to use mpileup instead of pileup.

### DIFF
--- a/modules/VertRes/Utils/Sam.pm
+++ b/modules/VertRes/Utils/Sam.pm
@@ -3708,6 +3708,8 @@ sub coverage
 {
     my ($self, $bam, @bin) = @_;
 
+    if( ! -e $bam ){ $self->throw("Input file not found: $bam\n"); }
+
     unless(@bin){ @bin = (1); } # Default to 1X coverage.
 
     # Sort coverage depths into ascending order.
@@ -3735,6 +3737,7 @@ sub coverage
 	} 
     }
     close $fh;
+    unless( $sam->run_status() ){ $self->throw("Samtools pileup failed for: $bam\n"); }
 
     return @cover;
 }

--- a/modules/VertRes/Wrapper/samtools.pm
+++ b/modules/VertRes/Wrapper/samtools.pm
@@ -236,13 +236,14 @@ sub merge_and_check {
  Returns : n/a
  Args    : list of file paths, options as a hash. If using the 'open' run_method
            you should set the second arg to undef.
+ Note    : pileup was removed from samtools using mpileup instead.
 
 =cut
 
 sub pileup {
     my ($self, $in_file, $out_file, %options) = @_;
     
-    $self->exe($self->{base_exe}.' pileup');
+    $self->exe($self->{base_exe}.' mpileup');
     
     $self->switches([qw(s i c g S a 2)]);
     $self->params([qw(m M t l f T N r G I)]);


### PR DESCRIPTION
I've set the samtools wrapper to run mpileup instead of pileup. 

Pileup has been removed from samtools so anything trying to use the wrapper to run samtools pileup on a recent version of samtools will fail. 

So saying, I suspect the only thing using the wrapper to run pileup is the genome coverage option in the mapping pipeline. And I'm planning to fix the genome coverage option next week.
