### PR TITLE
Added do_samtools_rmdup parameter to LSF script that calls run_graphs().

### DIFF
--- a/modules/VertRes/Pipelines/TrackQC_Bam.pm
+++ b/modules/VertRes/Pipelines/TrackQC_Bam.pm
@@ -512,6 +512,7 @@ my \%params =
     'stats_ref'    => q[$stats_ref],
     'chr_regex'    => q[$$self{chr_regex}],
     'bamcheck'     => q[$$self{bamcheck}],
+    'do_samtools_rmdup' => q[$$self{do_samtools_rmdup}]
 );
 
 my \$qc = VertRes::Pipelines::TrackQC_Bam->new(\%params);

--- a/modules/VertRes/Pipelines/TrackQC_Fastq.pm
+++ b/modules/VertRes/Pipelines/TrackQC_Fastq.pm
@@ -734,6 +734,7 @@ my \%params =
     'bwa_clip'     => q[$$self{bwa_clip}],
     'chr_regex'    => q[$$self{chr_regex}],
     'bwa_exec'     => q[$$self{bwa_exec}],
+    'do_samtools_rmdup' => q[$$self{do_samtools_rmdup}]
 );
 
 my \$qc = VertRes::Pipelines::TrackQC_Fastq->new(\%params);


### PR DESCRIPTION
During QC, run_graphs() is called from an LSF script so any parameters have to be passed via this script or else run_graphs goes with the defaults. 
