### PR TITLE
Updates to Sfind and rmdup config option

### DIFF
--- a/modules/Sfind/Library.pm
+++ b/modules/Sfind/Library.pm
@@ -253,7 +253,7 @@ has 'tag_id'  => (
     is          => 'ro',
     isa         => 'Maybe[Int]',
     #init_arg    => 'tag_internal_id', # this is the actual tag int id, not the id in the bamfile name
-    init_arg    => 'tag_map_id',
+    init_arg    => 'tag_id',
 );
 
 has 'tag_group_id'  => (
@@ -318,7 +318,7 @@ around BUILDARGS => sub {
         aliquot.tag_uuid,
         aliquot.tag_internal_id,
         library_tube.expected_sequence,
-        library_tube.tag_map_id,
+        tags.map_id as tag_id,
         library_tube.tag_group_name,
         library_tube.tag_group_uuid,
         library_tube.tag_group_internal_id,
@@ -331,6 +331,7 @@ around BUILDARGS => sub {
         library_tube.scanned_in_date,
         library_tube.public_name from current_library_tubes  as library_tube
     join aliquots as aliquot on aliquot.receptacle_type = "library_tube" and aliquot.library_internal_id = library_tube.internal_id
+    left join current_tags as tags on tags.internal_id = aliquot.tag_internal_id
     where library_tube.internal_id = ? order by aliquot.tag_internal_id desc limit 1];
 
     my $id_ref = $argref->{dbh}->selectrow_hashref($sql, undef, ($argref->{id}));
@@ -406,7 +407,7 @@ sub _get_mplex_pool_ids{
     my ($self) = @_;
     my @mplex_ids;
 
-    my $sql = qq[select descendant_internal_id as mplex_id
+    my $sql = qq[select distinct descendant_internal_id as mplex_id
                 from asset_links 
                 where ancestor_type="library_tubes" 
                 and ancestor_internal_id=?
@@ -428,7 +429,7 @@ sub _get_mplex_pool_ids{
 
 sub _get_is_tagged {
     my ($self) = @_;
-    my $tag = $self->tag_id ? 1 : 0;
+    my $tag = ($self->tag_id && $self->tag_id >= 0) ? 1 : 0;
     return $tag;
 }
 

--- a/modules/Sfind/Library.pm
+++ b/modules/Sfind/Library.pm
@@ -331,11 +331,8 @@ around BUILDARGS => sub {
         library_tube.scanned_in_date,
         library_tube.public_name from current_library_tubes  as library_tube
     join aliquots as aliquot on aliquot.receptacle_type = "library_tube" and aliquot.library_internal_id = library_tube.internal_id
-    where library_tube.internal_id = ?;];
-    
+    where library_tube.internal_id = ? order by aliquot.tag_internal_id desc limit 1];
 
-    
-    
     my $id_ref = $argref->{dbh}->selectrow_hashref($sql, undef, ($argref->{id}));
     if ($id_ref){
         foreach my $field(keys %$id_ref){

--- a/modules/Sfind/Library.pm
+++ b/modules/Sfind/Library.pm
@@ -303,7 +303,39 @@ around BUILDARGS => sub {
     my $argref = $class->$orig(@_);
 
     die "Need to call with a librarytube asset id" unless $argref->{id};
-    my $sql = qq[select * from current_library_tubes where internal_id = ? ];
+    my $sql = qq[select     library_tube.uuid,
+        library_tube.internal_id,
+        library_tube.name,
+        library_tube.barcode,
+        library_tube.barcode_prefix,
+        library_tube.closed,
+        library_tube.state,
+        library_tube.two_dimensional_barcode,
+        aliquot.sample_uuid,
+        aliquot.sample_internal_id,
+        library_tube.volume,
+        library_tube.concentration,
+        aliquot.tag_uuid,
+        aliquot.tag_internal_id,
+        library_tube.expected_sequence,
+        library_tube.tag_map_id,
+        library_tube.tag_group_name,
+        library_tube.tag_group_uuid,
+        library_tube.tag_group_internal_id,
+        library_tube.source_request_internal_id,
+        library_tube.source_request_uuid,
+        library_tube.library_type,
+        aliquot.insert_size_from as fragment_size_required_from,
+        aliquot.insert_size_to as fragment_size_required_to,
+        library_tube.sample_name,
+        library_tube.scanned_in_date,
+        library_tube.public_name from current_library_tubes  as library_tube
+    join aliquots as aliquot on aliquot.receptacle_type = "library_tube" and aliquot.library_internal_id = library_tube.internal_id
+    where library_tube.internal_id = ?;];
+    
+
+    
+    
     my $id_ref = $argref->{dbh}->selectrow_hashref($sql, undef, ($argref->{id}));
     if ($id_ref){
         foreach my $field(keys %$id_ref){

--- a/modules/Sfind/Library_Request.pm
+++ b/modules/Sfind/Library_Request.pm
@@ -228,14 +228,14 @@ sub _get_library_ids {
         # for a non-multiplex request, or the indexed library tube that will be
         # pooled for a multiplexed request
 
-        my $sql= qq[select target_asset_internal_id, target_asset_type from current_requests where internal_id=? ];
-          
+        my $sql= qq[select distinct aliquot.library_internal_id as target_asset_internal_id, aliquot.receptacle_type as target_asset_type  from aliquots as aliquot join current_requests as request on request.target_asset_internal_id = aliquot.receptacle_internal_id where request.internal_id = ?];
+
         my $sth = $self->{_dbh}->prepare($sql);
 
         $sth->execute($self->id);
         foreach(@{$sth->fetchall_arrayref()}){
             if ($_->[0]){
-                die "Unexpected target type ".$_->[1] unless $_->[1] eq 'library_tubes';
+                die "Unexpected target type ".$_->[1] unless $_->[1] eq 'library_tube';
                 push @lib_ids, $_->[0];
             }
         }

--- a/modules/VRTrack/VRTrack.pm
+++ b/modules/VRTrack/VRTrack.pm
@@ -45,7 +45,7 @@ use VRTrack::Lane;
 use VRTrack::File;
 use VRTrack::Core_obj;
 
-use constant SCHEMA_VERSION => '16';
+use constant SCHEMA_VERSION => '17';
 
 our $DEFAULT_PORT = 3306;
 
@@ -1084,7 +1084,7 @@ CREATE TABLE `seq_request` (
   `library_id` smallint(5) unsigned,
   `multiplex_pool_id` smallint(5) unsigned,
   `ssid` mediumint(8) unsigned DEFAULT NULL,
-  `seq_type` enum('Single ended sequencing','Paired end sequencing','HiSeq Paired end sequencing','MiSeq sequencing') DEFAULT 'Single ended sequencing',
+  `seq_type` enum('Single ended sequencing','Paired end sequencing','HiSeq Paired end sequencing','MiSeq sequencing','Single ended hi seq sequencing') DEFAULT 'Single ended sequencing',
   `seq_status` enum('unknown','pending','started','passed','failed','cancelled','hold') DEFAULT 'unknown',
   `note_id` mediumint(8) unsigned DEFAULT NULL,
   `changed` datetime NOT NULL,

--- a/modules/VRTrack/VRTrack.pm
+++ b/modules/VRTrack/VRTrack.pm
@@ -877,7 +877,7 @@ CREATE TABLE `schema_version` (
   PRIMARY KEY  (`schema_version`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
-insert into schema_version(schema_version) values (16);
+insert into schema_version(schema_version) values (17);
 
 --
 -- Table structure for table `assembly`

--- a/modules/VertRes/Pipelines/SNPs.pm
+++ b/modules/VertRes/Pipelines/SNPs.pm
@@ -984,6 +984,12 @@ sub mpileup_postprocess
     my $basename = $$vcfs[0];
     $basename =~ s/\.gz$//i;
     $basename =~ s/\.vcf$//i;
+    my $mapstat_id = $basename;
+    $mapstat_id =~  s/^.+\/([\d]+)\.[^\/]+\/[^\/]+$/$1/;
+    if( $mapstat_id =~ /[\D]+/)
+    {
+      $mapstat_id = time();
+    }
 
     return qq[
 use strict;
@@ -1002,6 +1008,14 @@ Utils::CMD("zcat $basename.filt.vcf.gz | $$self{vcf_stats} > $name.vcf.gz.stats"
 Utils::CMD("tabix -f -p vcf $basename.filt.vcf.gz");
 rename("$basename.filt.vcf.gz.tbi","$name.vcf.gz.tbi") or Utils::error("rename $basename.filt.vcf.gz.tbi $name.vcf.gz.tbi: \$!");
 rename("$basename.filt.vcf.gz","$name.vcf.gz") or Utils::error("rename $basename.filt.vcf.gz $name.vcf.gz: \$!");
+
+symlink("$name.vcf.gz.tbi", "$mapstat_id.vcf.gz.tbi");
+symlink("$name.vcf.gz.stats", "$mapstat_id.vcf.gz.stats");
+symlink("$name.vcf.gz", "$mapstat_id.vcf.gz");
+
+symlink("$name.unfilt.vcf.gz.tbi", "$mapstat_id.unfilt.vcf.gz.tbi");
+symlink("$name.unfilt.vcf.gz.stats", "$mapstat_id.unfilt.vcf.gz.stats");
+symlink("$name.unfilt.vcf.gz", "$mapstat_id.unfilt.vcf.gz");
 
 ];
 }

--- a/modules/VertRes/Pipelines/SNPs.pm
+++ b/modules/VertRes/Pipelines/SNPs.pm
@@ -984,12 +984,6 @@ sub mpileup_postprocess
     my $basename = $$vcfs[0];
     $basename =~ s/\.gz$//i;
     $basename =~ s/\.vcf$//i;
-    my $mapstat_id = $basename;
-    $mapstat_id =~  s/^.+\/([\d]+)\.[^\/]+\/[^\/]+$/$1/;
-    if( $mapstat_id =~ /[\D]+/)
-    {
-      $mapstat_id = time();
-    }
 
     return qq[
 use strict;
@@ -1008,14 +1002,6 @@ Utils::CMD("zcat $basename.filt.vcf.gz | $$self{vcf_stats} > $name.vcf.gz.stats"
 Utils::CMD("tabix -f -p vcf $basename.filt.vcf.gz");
 rename("$basename.filt.vcf.gz.tbi","$name.vcf.gz.tbi") or Utils::error("rename $basename.filt.vcf.gz.tbi $name.vcf.gz.tbi: \$!");
 rename("$basename.filt.vcf.gz","$name.vcf.gz") or Utils::error("rename $basename.filt.vcf.gz $name.vcf.gz: \$!");
-
-symlink("$name.vcf.gz.tbi", "$mapstat_id.vcf.gz.tbi");
-symlink("$name.vcf.gz.stats", "$mapstat_id.vcf.gz.stats");
-symlink("$name.vcf.gz", "$mapstat_id.vcf.gz");
-
-symlink("$name.unfilt.vcf.gz.tbi", "$mapstat_id.unfilt.vcf.gz.tbi");
-symlink("$name.unfilt.vcf.gz.stats", "$mapstat_id.unfilt.vcf.gz.stats");
-symlink("$name.unfilt.vcf.gz", "$mapstat_id.unfilt.vcf.gz");
 
 ];
 }

--- a/modules/VertRes/Pipelines/TrackQC_Bam.pm
+++ b/modules/VertRes/Pipelines/TrackQC_Bam.pm
@@ -512,6 +512,7 @@ my \%params =
     'stats_ref'    => q[$stats_ref],
     'chr_regex'    => q[$$self{chr_regex}],
     'bamcheck'     => q[$$self{bamcheck}],
+    'do_samtools_rmdup' => q[$$self{do_samtools_rmdup}]
 );
 
 my \$qc = VertRes::Pipelines::TrackQC_Bam->new(\%params);

--- a/modules/VertRes/Pipelines/TrackQC_Fastq.pm
+++ b/modules/VertRes/Pipelines/TrackQC_Fastq.pm
@@ -734,6 +734,7 @@ my \%params =
     'bwa_clip'     => q[$$self{bwa_clip}],
     'chr_regex'    => q[$$self{chr_regex}],
     'bwa_exec'     => q[$$self{bwa_exec}],
+    'do_samtools_rmdup' => q[$$self{do_samtools_rmdup}]
 );
 
 my \$qc = VertRes::Pipelines::TrackQC_Fastq->new(\%params);

--- a/sql/VRTrack_schema_16_to_17.sql
+++ b/sql/VRTrack_schema_16_to_17.sql
@@ -1,0 +1,4 @@
+ALTER TABLE seq_request MODIFY seq_type ENUM('Single ended sequencing','Paired end sequencing','HiSeq Paired end sequencing','MiSeq sequencing','Single ended hi seq sequencing')  NOT NULL; 
+DROP VIEW if EXISTS `latest_seq_request`;
+create view latest_seq_request as select * from seq_request where latest=true;
+update schema_version set schema_version=17;


### PR DESCRIPTION
Sequencescape have updated their internal model to track aliquots. So an asset can contain more than 1 sample. New multiplexed lanes will randomly work depending on the order rows are returned from the database.  I've updated Sfind to make it work for a standard multiplexed library tube but you'll need to update the Well libraries code since your the only ones using it.

Also in this pull request is to allow for rmdup to be a configurable option, since we use it, and you guys stopped using it.
