### PR TITLE
Sample hierarchy

### DIFF
--- a/scripts/vrtracking_tool
+++ b/scripts/vrtracking_tool
@@ -371,28 +371,22 @@ sub get_vrtrack_objects
 
 sub get_vrtrack_directory
 {
-	my ($vrtrack, $vrobject) = @_;
-	if ($vrobject->isa('VRTrack::Lane')) {
-		return $vrtrack->hierarchy_path_of_lane_name($vrobject->name);
-	}
-	#project:sample:technology:library
-	elsif ($vrobject->isa('VRTrack::Library')) {
-		my $sample = VRTrack::Sample->new($vrtrack, $vrobject->sample_id);
-		my $project = VRTrack::Project->new($vrtrack, $sample->project_id);
-		my $seq_tech_name = $vrobject->seq_tech() ? $vrobject->seq_tech->name : 'SLX';
-		return File::Spec->catdir($project->hierarchy_name, $sample->hierarchy_name, $seq_tech_name, $vrobject->hierarchy_name);
-	}
-	elsif ($vrobject->isa('VRTrack::Sample')) {
-		my $project = VRTrack::Project->new($vrtrack, $vrobject->project_id);
-		return File::Spec->catdir($project->hierarchy_name, $vrobject->hierarchy_name)
-	}	
-	elsif ($vrobject->isa('VRTrack::Project')) {
-		return $vrobject->hierarchy_name;	
-	}
-	else {
-		croak "Unable to retrieve the tracking directory as the tracking object type is not recognised.\n";
-	}		
-}	
+    my ($vrtrack, $vrobject) = @_;
+
+    my %recognised_type = ('VRTrack::Project' => 1,
+			   'VRTrack::Sample'  => 1,
+			   'VRTrack::Library' => 1,
+			   'VRTrack::Lane'    => 1);
+    
+    # Check object
+    croak "Unable to retrieve the tracking directory as the tracking object is not defined.\n"         unless defined $vrobject;
+    croak "Unable to retrieve the tracking directory as the tracking object type is not recognised.\n" unless $recognised_type{ref($vrobject)};
+
+    my $vrtrack_directory = $vrtrack->hierarchy_path_of_object($vrobject);
+    croak "Unable to retrieve the tracking directory as could not build hierarchy path for tracking object.\n" unless defined $vrtrack_directory;
+
+    return $vrtrack_directory;
+}
 
 sub get_reset_flag_objects
 {


### PR DESCRIPTION
I tried deleting samples from one of our tracking databases and found that vrtracking_tools wasn't returning the directory path to the samples that I expected. I found that the program wasn't using the DATA_HIERARCHY environment variable. Our directory structure is, "genus:species-subspecies:TRACKING:projectssid:sample:technology:library:lane".

The solution that I came up with was to add a general function for finding the hierarchy path to a Project, Sample, Library or Lane to the VRTrack module.

There are two commits:

The change to VRTrack.pm adding a function heirarchy_path_of_object() based on heirarchy_path_of_lane() and setting heirarchy_path_of_lane() to call the new function. I've also added a set of unit tests for the new function.

The change to vrtracking_tools to use the heirarchy_path_of_object().

Note:
The POD documentation states that hierarchy_path_of_lane() returns undef if a hierarchy cannot be built so hierarchy_path_of_object() is set to return undef if a hierarchy cannot be built for any reason. For instance, if species is part of the hierarchy and species data isn't available then the function will return undef.
