### PR TITLE
Feature/cr queue

### DIFF
--- a/modules/RunnerLSFCR.pm
+++ b/modules/RunnerLSFCR.pm
@@ -264,6 +264,15 @@ sub run_jobs
 }
 
 
+sub _get_queue
+{
+    my ($self,$time) = @_;
+    my $queue = exists($$self{limits}{queue}) ? $$self{limits}{queue} : $$self{default_limits}{queue};
+    return $queue;
+}
+
+
+
 =head1 AUTHORS
 
 Allan Daly <ad7@sanger.ac.uk>


### PR DESCRIPTION
Changed the queue selection when blcr checkpointing is set so that the default is set to the normal queue
